### PR TITLE
Add UUPSUpgradeable to Mage

### DIFF
--- a/src/Mage.sol
+++ b/src/Mage.sol
@@ -6,13 +6,14 @@ import {Guards} from "./guard/Guards.sol";
 import {Extensions} from "./extension/Extensions.sol";
 import {Execute} from "./lib/Execute.sol";
 import {Multicall} from "openzeppelin-contracts/utils/Multicall.sol";
+import {UUPSUpgradeable} from "openzeppelin-contracts/proxy/utils/UUPSUpgradeable.sol";
 
 /**
  * A Solidity framework for creating complex and evolving onchain structures.
  * Mage is an acronym for the architecture pattern's four layers: Module, Access, Guard, and Extension.
  * All Mage-inherited contracts receive a batteries-included contract development kit.
  */
-contract Mage is Access, Guards, Extensions, Execute, Multicall {
+contract Mage is Access, Guards, Extensions, Execute, Multicall, UUPSUpgradeable {
     function contractURI() public view virtual returns (string memory uri) {}
 
     function supportsInterface(bytes4 interfaceId)
@@ -39,6 +40,10 @@ contract Mage is Access, Guards, Extensions, Execute, Multicall {
     }
 
     function _checkCanExecute() internal view override {
+        _checkSenderIsAdmin();
+    }
+
+    function _authorizeUpgrade(address) internal view override {
         _checkSenderIsAdmin();
     }
 }


### PR DESCRIPTION
Because Mage is a framework for upgradeable systems, we follow UUPS as the default implementation for Mage-inherited contracts. The `_authorizeUpgrade` function cleanly follows from our other permission adapters by setting the `ADMIN` as having upgrade permissions.