### PR TITLE
Revert Permissions permit/execute differentiation

### DIFF
--- a/src/access/Access.sol
+++ b/src/access/Access.sol
@@ -9,24 +9,19 @@ abstract contract Access is Permissions {
     // support multiple owner implementations, e.g. explicit storage vs NFT-owner (ERC-6551)
     function owner() public view virtual returns (address);
 
-    function hasPermission(bytes8 operation, PermissionsStorage.OperationVariant variant, address account)
-        public
-        view
-        override
-        returns (bool)
-    {
+    function hasPermission(bytes8 operation, address account) public view override returns (bool) {
         // 3 tiers: has operation permission, has admin permission, or is owner
-        if (super.hasPermission(operation, variant, account)) {
+        if (super.hasPermission(operation, account)) {
             return true;
         }
-        if (operation != Operations.ADMIN && super.hasPermission(Operations.ADMIN, variant, account)) {
+        if (operation != Operations.ADMIN && super.hasPermission(Operations.ADMIN, account)) {
             return true;
         }
         return account == owner();
     }
 
     function _checkSenderIsAdmin() internal view {
-        _checkPermission(Operations.ADMIN, PermissionsStorage.OperationVariant.EXECUTE, msg.sender);
+        _checkPermission(Operations.ADMIN, msg.sender);
     }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {

--- a/src/access/permissions/Permissions.sol
+++ b/src/access/permissions/Permissions.sol
@@ -18,30 +18,21 @@ abstract contract Permissions is PermissionsInternal, IPermissionsExternal {
         SETTERS
     =============*/
 
-    function setPermission(bytes8 operation, Storage.OperationVariant variant, address account)
-        public
-        virtual
-        canUpdatePermissions
-    {
-        _setPermission(operation, variant, account);
+    function addPermission(bytes8 operation, address account) public virtual {
+        _checkCanUpdatePermissions();
+        _addPermission(operation, account);
     }
 
-    function removePermission(bytes8 operation, address account) public virtual canUpdatePermissions {
+    function removePermission(bytes8 operation, address account) public virtual {
+        if (account != msg.sender) {
+            _checkCanUpdatePermissions();
+        }
         _removePermission(operation, account);
-    }
-
-    function renouncePermission(bytes8 operation) public virtual {
-        _removePermission(operation, msg.sender);
     }
 
     /*===================
         AUTHORIZATION
     ===================*/
-
-    modifier canUpdatePermissions() {
-        _checkCanUpdatePermissions();
-        _;
-    }
 
     function _checkCanUpdatePermissions() internal virtual;
 }

--- a/src/access/permissions/PermissionsStorage.sol
+++ b/src/access/permissions/PermissionsStorage.sol
@@ -14,13 +14,6 @@ library PermissionsStorage {
         uint24 index; //              [0..23]
         uint40 updatedAt; //          [24..63]
         bool exists; //              [64-71]
-        OperationVariant variant; // [72-79]
-   } 
-
-    enum OperationVariant {
-        PERMIT,
-        EXECUTE,
-        PERMIT_AND_EXECUTE
     }
 
     function layout() internal pure returns (Layout storage l) {

--- a/src/access/permissions/interface/IPermissions.sol
+++ b/src/access/permissions/interface/IPermissions.sol
@@ -6,34 +6,28 @@ import {PermissionsStorage} from "../PermissionsStorage.sol";
 interface IPermissionsInternal {
     struct Permission {
         bytes8 operation;
-        PermissionsStorage.OperationVariant variant;
         address account;
         uint40 updatedAt;
     }
 
     // events
-    event PermissionUpdated(
-        bytes8 indexed operation, address indexed account, PermissionsStorage.OperationVariant indexed variant
-    );
-    event PermissionRemoved(
-        bytes8 indexed operation, address indexed account, PermissionsStorage.OperationVariant indexed variant
-    );
+    event PermissionAdded(bytes8 indexed operation, address indexed account);
+    event PermissionRemoved(bytes8 indexed operation, address indexed account);
 
     // errors
+    error PermissionAlreadyExists(bytes8 operation, address account);
     error PermissionDoesNotExist(bytes8 operation, address account);
-    error PermissionInvalid(bytes8 operation, PermissionsStorage.OperationVariant variant, address account);
 
     // views
     function hashOperation(string memory name) external view returns (bytes8);
-    function hasPermission(bytes8 operation, PermissionsStorage.OperationVariant, address account) external view returns (bool);
+    function hasPermission(bytes8 operation, address account) external view returns (bool);
     function getAllPermissions() external view returns (Permission[] memory permissions);
 }
 
 interface IPermissionsExternal {
     // setters
-    function setPermission(bytes8 operation, PermissionsStorage.OperationVariant variant, address account) external;
+    function addPermission(bytes8 operation, address account) external;
     function removePermission(bytes8 operation, address account) external;
-    function renouncePermission(bytes8 operation) external;
 }
 
 interface IPermissions is IPermissionsInternal, IPermissionsExternal {}

--- a/src/cores/ERC721/ERC721Mage.sol
+++ b/src/cores/ERC721/ERC721Mage.sol
@@ -76,15 +76,13 @@ contract ERC721Mage is Mage, Ownable, Initializer, ERC721AUpgradeable, IERC721Ma
         SETTERS
     =============*/
 
-    function mintTo(address recipient, uint256 quantity) 
-        external onlyPermission(Operations.MINT, PermissionsStorage.OperationVariant.EXECUTE) 
-    {
+    function mintTo(address recipient, uint256 quantity) external onlyPermission(Operations.MINT) {
         _safeMint(recipient, quantity);
     }
 
     function burn(uint256 tokenId) external {
         if (msg.sender != ownerOf(tokenId)) {
-            _checkPermission(Operations.BURN, PermissionsStorage.OperationVariant.EXECUTE, msg.sender);
+            _checkPermission(Operations.BURN, msg.sender);
         }
         _burn(tokenId);
     }

--- a/src/lib/Operations.sol
+++ b/src/lib/Operations.sol
@@ -8,6 +8,7 @@ library Operations {
     bytes8 constant TRANSFER = 0x5cc15eb80ba37777; // hashOperation("TRANSFER");
     bytes8 constant METADATA = 0x0e5de49ee56c0bd3; // hashOperation("METADATA");
 
+    // TODO: deprecate and find another way versus anti-pattern
     // permits are enabling the permission, but only through set up modules/extension logic
     // e.g. someone can approve new members to mint, but cannot circumvent the module for taking payment
     bytes8 constant MINT_PERMIT = 0x0b6c53f325d325d3; // hashOperation("MINT_PERMIT");

--- a/test/access/Access.t.sol
+++ b/test/access/Access.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import {Test} from "forge-std/Test.sol";
 import {Access} from "src/access/Access.sol";
-import {PermissionsStorage} from "src/access/permissions/PermissionsStorage.sol";
 import {Operations} from "src/lib/Operations.sol";
 
 contract AccessTest is Test, Access {
@@ -20,20 +19,18 @@ contract AccessTest is Test, Access {
         supportedOps.push(Operations.METADATA);
     }
 
-    function test_hasPermissionOperation(address account, uint8 _variant) public {
+    function test_hasPermissionOperation(address account) public {
         address unpermittedAddress = address(0xbeefEbabe);
         vm.assume(account != unpermittedAddress);
-
-        PermissionsStorage.OperationVariant variant = PermissionsStorage.OperationVariant(_variant % 3 );
 
         // grant each operation and assert checks
         for (uint256 i; i < supportedOps.length; ++i) {
             bytes8 currentOp = supportedOps[i];
-            setPermission(currentOp, variant, account);
-            assertTrue(hasPermission(currentOp, variant, account));
+            addPermission(currentOp, account);
+            assertTrue(hasPermission(currentOp, account));
 
             // assert unpermittedAddress returns false
-            assertFalse(hasPermission(currentOp, variant, unpermittedAddress));
+            assertFalse(hasPermission(currentOp, unpermittedAddress));
         }
     }
 
@@ -43,11 +40,11 @@ contract AccessTest is Test, Access {
 
         // grant admin operation and assert checks
         bytes8 adminOp = supportedOps[0];
-        setPermission(adminOp, PermissionsStorage.OperationVariant.EXECUTE, account);
-        assertTrue(hasPermission(adminOp, PermissionsStorage.OperationVariant.EXECUTE, account));
+        addPermission(adminOp, account);
+        assertTrue(hasPermission(adminOp, account));
 
         // assert unpermittedAddress returns false
-        assertFalse(hasPermission(adminOp, PermissionsStorage.OperationVariant.EXECUTE, unpermittedAddress));
+        assertFalse(hasPermission(adminOp, unpermittedAddress));
     }
 
     function test_hasPermissionOwner(bytes8 randomOp) public {
@@ -56,10 +53,10 @@ contract AccessTest is Test, Access {
 
         for (uint256 i; i < supportedOps.length; ++i) {
             bytes8 currentOp = supportedOps[i];
-            assertTrue(hasPermission(currentOp, PermissionsStorage.OperationVariant.EXECUTE, owner()));
+            assertTrue(hasPermission(currentOp, owner()));
         }
 
-        assertTrue(hasPermission(randomOp, PermissionsStorage.OperationVariant.EXECUTE, owner()));
+        assertTrue(hasPermission(randomOp, owner()));
     }
 
     /*==============


### PR DESCRIPTION
After bringing the changes through our modules and frontend use of the ABIs, this change no longer has the clean perception we had when starting it. In light of a pending design question on modularizing signature validation for Account primitives, there is a potential overlap in the intended PERMIT enum and this kind of feature set. For now, keeping `Permissions` as a 2-dimensional allowlist for enabling the externalization of logic into modules is a clean and confident step away from a 1-dimensional allowlist.

Shortly, we will look at modularizing signature validation after looking at the latest in the ecosystem around ERC-6900, Safe's new whitepaper, and other places. This also gives us time to appropriately design for scoping signing permissions even more granularly than we could before, scoping them to a single or set of modules.