### PR TITLE
Rewrite ERC721A with ERC-7201

### DIFF
--- a/src/cores/ERC721/ERC721.sol
+++ b/src/cores/ERC721/ERC721.sol
@@ -10,6 +10,15 @@ abstract contract ERC721 is ERC721Internal, IERC721External {
         VIEWS
     ===========*/
 
+    /// @dev require override
+    function name() public view virtual returns (string memory);
+
+    /// @dev require override
+    function symbol() public view virtual returns (string memory);
+
+    /// @dev require override
+    function tokenURI(uint256 tokenId) public view virtual returns (string memory);
+
     function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         // The interface IDs are constants representing the first 4 bytes
         // of the XOR of all function selectors in the interface.
@@ -27,7 +36,7 @@ abstract contract ERC721 is ERC721Internal, IERC721External {
     function approve(address to, uint256 tokenId) public virtual {
         _approve(to, tokenId);
     }
-    
+
     function setApprovalForAll(address operator, bool approved) public virtual {
         _setApprovalForAll(operator, approved);
     }

--- a/src/cores/ERC721/ERC721.sol
+++ b/src/cores/ERC721/ERC721.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {InterfaceExternal} from "./Interface.sol";
+import {Internal} from "./Internal.sol";
+import {Storage} from "./Storage.sol";
+
+abstract contract External is Internal, InterfaceExternal {
+    /*===========
+        VIEWS
+    ===========*/
+
+    /*=============
+        SETTERS
+    =============*/
+    function bar() external virtual {}
+
+    /*====================
+        AUTHORITZATION
+    ====================*/
+}

--- a/src/cores/ERC721/ERC721.sol
+++ b/src/cores/ERC721/ERC721.sol
@@ -1,19 +1,51 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {InterfaceExternal} from "./Interface.sol";
-import {Internal} from "./Internal.sol";
-import {Storage} from "./Storage.sol";
+import {IERC721External} from "./IERC721.sol";
+import {ERC721Internal} from "./ERC721Internal.sol";
+import {ERC721Storage} from "./ERC721Storage.sol";
 
-abstract contract External is Internal, InterfaceExternal {
+abstract contract ERC721 is ERC721Internal, IERC721External {
     /*===========
         VIEWS
     ===========*/
 
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        // The interface IDs are constants representing the first 4 bytes
+        // of the XOR of all function selectors in the interface.
+        // See: [ERC165](https://eips.ethereum.org/EIPS/eip-165)
+        // (e.g. `bytes4(i.functionA.selector ^ i.functionB.selector ^ ...)`)
+        return interfaceId == 0x01ffc9a7 // ERC165 interface ID for ERC165.
+            || interfaceId == 0x80ac58cd // ERC165 interface ID for ERC721.
+            || interfaceId == 0x5b5e139f; // ERC165 interface ID for ERC721Metadata.
+    }
+
     /*=============
         SETTERS
     =============*/
-    function bar() external virtual {}
+
+    function approve(address to, uint256 tokenId) public virtual {
+        _approve(to, tokenId);
+    }
+    
+    function setApprovalForAll(address operator, bool approved) public virtual {
+        _setApprovalForAll(operator, approved);
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public {
+        _checkCanTransfer(from, tokenId);
+        _transfer(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) public {
+        transferFrom(from, to, tokenId);
+        _checkOnERC721Received(from, to, tokenId, "");
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public {
+        transferFrom(from, to, tokenId);
+        _checkOnERC721Received(from, to, tokenId, data);
+    }
 
     /*====================
         AUTHORITZATION

--- a/src/cores/ERC721/ERC721AUpgradeable.sol
+++ b/src/cores/ERC721/ERC721AUpgradeable.sol
@@ -131,18 +131,8 @@ contract ERC721AUpgradeable is Initializer, IERC721A {
     //     _currentIndex = _startTokenId();
     // }
 
-    function _initialize(string memory name_, string memory symbol_) internal onlyInitializing {
-        _setName(name_);
-        _setSymbol(symbol_);
+    function _initialize() internal onlyInitializing {
         _currentIndex = _startTokenId();
-    }
-
-    function _setName(string memory name_) internal {
-        _name = name_;
-    }
-
-    function _setSymbol(string memory symbol_) internal {
-        _symbol = symbol_;
     }
 
     // =============================================================

--- a/src/cores/ERC721/ERC721Internal.sol
+++ b/src/cores/ERC721/ERC721Internal.sol
@@ -19,15 +19,6 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
         VIEWS
     ===========*/
 
-    // metadata
-    /// @dev all need to be overridden
-
-    function name() public view virtual returns (string memory);
-
-    function symbol() public view virtual returns (string memory);
-
-    function tokenURI(uint256 tokenId) public view virtual returns (string memory);
-
     // global token values
 
     function _startTokenId() internal view virtual returns (uint256) {

--- a/src/cores/ERC721/ERC721Internal.sol
+++ b/src/cores/ERC721/ERC721Internal.sol
@@ -1,17 +1,28 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+import {Initializer} from "../../lib/Initializer/Initializer.sol";
 import {IERC721Internal, IERC721Receiver} from "./IERC721.sol";
 import {ERC721Storage} from "./ERC721Storage.sol";
 
-abstract contract ERC721Internal is IERC721Internal {
+abstract contract ERC721Internal is Initializer, IERC721Internal {
+    
+    /*================
+        INITIALIZE
+    ================*/
+
+    function _initialize() internal onlyInitializing {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        layout.currentIndex = uint64(_startTokenId());
+    }
+    
     /*===========
         VIEWS
     ===========*/
 
-    function name() external virtual returns (string memory);
+    function name() public view virtual returns (string memory);
     
-    function symbol() external virtual returns (string memory);
+    function symbol() public view virtual returns (string memory);
 
     function _startTokenId() internal view virtual returns (uint256) {
         return 0;

--- a/src/cores/ERC721/ERC721Internal.sol
+++ b/src/cores/ERC721/ERC721Internal.sol
@@ -140,7 +140,7 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
         
         uint256 startTokenId = layout.currentIndex;
 
-        bytes memory beforeCheckData = _beforeTokenTransfers(address(0), to, startTokenId, quantity);
+        (address guard, bytes memory beforeCheckData) = _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
         ERC721Storage.OwnerData storage ownerData = layout.owners[to];
         ownerData.balance += uint64(quantity);
@@ -155,7 +155,7 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
         }
         layout.currentIndex = uint64(endIndex);
         
-        _afterTokenTransfers(beforeCheckData);
+        _afterTokenTransfers(guard, beforeCheckData);
     }
 
     function _burn(uint256 tokenId) internal {
@@ -166,7 +166,7 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
 
         // approvals?
 
-        bytes memory beforeCheckData = _beforeTokenTransfers(from, address(0), tokenId, 1);
+        (address guard, bytes memory beforeCheckData) = _beforeTokenTransfers(from, address(0), tokenId, 1);
 
         // clear approval from previous owner
         delete layout.tokenApprovals[tokenId];
@@ -198,7 +198,7 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
         layout.burnCounter++;
 
         emit Transfer(from, address(0), tokenId);
-        _afterTokenTransfers(beforeCheckData);
+        _afterTokenTransfers(guard, beforeCheckData);
     }
 
     function _transfer(address from, address to, uint256 tokenId) internal {
@@ -212,7 +212,7 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
 
         // approvals?
 
-        bytes memory beforeCheckData = _beforeTokenTransfers(from, to, tokenId, 1);
+        (address guard, bytes memory beforeCheckData) = _beforeTokenTransfers(from, to, tokenId, 1);
 
         // clear approval from previous owner
         delete layout.tokenApprovals[tokenId];
@@ -241,7 +241,7 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
         }
 
         emit Transfer(from, to, tokenId);
-        _afterTokenTransfers(beforeCheckData);
+        _afterTokenTransfers(guard, beforeCheckData);
     }
 
     function _safeMint(address to, uint256 quantity) internal virtual {
@@ -299,7 +299,7 @@ abstract contract ERC721Internal is Initializer, IERC721Internal {
         }
     }
 
-    function _beforeTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity) internal virtual returns (bytes memory) {}
+    function _beforeTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity) internal virtual returns (address guard, bytes memory beforeCheckData) {}
 
-    function _afterTokenTransfers(bytes memory beforeCheckData) internal virtual {}
+    function _afterTokenTransfers(address guard, bytes memory beforeCheckData) internal virtual {}
 }

--- a/src/cores/ERC721/ERC721Internal.sol
+++ b/src/cores/ERC721/ERC721Internal.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IERC721Internal} from "./IERC721.sol";
+import {ERC721Storage} from "./ERC721Storage.sol";
+
+abstract contract Internal is IERC721Internal {
+    /*===========
+        VIEWS
+    ===========*/
+    function foo() external virtual {}
+
+    /*=============
+        SETTERS
+    =============*/
+
+    /**
+     * @dev Mints `quantity` tokens and transfers them to `to`.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `quantity` must be greater than 0.
+     *
+     * Emits a {Transfer} event for each mint.
+     */
+    function _mint(address to, uint256 quantity) internal virtual {
+        if (quantity == 0) revert MintZeroQuantity();
+        if (to == address(0)) revert MintToZeroAddress();
+
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        
+        uint256 startTokenId = layout.currentIndex;
+
+        _beforeTokenTransfers(address(0), to, startTokenId, quantity);
+
+        ERC721Storage.OwnerData storage ownerData = layout.owners[to];
+        ownerData.balance += uint64(quantity);
+        ownerData.numMinted += uint64(quantity);
+
+        ERC721Storage.TokenData memory tokenData = ERC721Storage.TokenData(to, false, quantity == 1, false);
+        layout.tokens[startTokenId] = tokenData;
+
+        uint256 endIndex = startTokenId + quantity;
+        for (uint256 tokenId = startTokenId; tokenId < endIndex; tokenId++) {
+            emit Transfer(address(0), to, tokenId);
+        }
+        layout.currentIndex = endIndex;
+        
+        _afterTokenTransfers(address(0), to, startTokenId, quantity);
+    }
+
+    /**
+     * @dev Destroys `tokenId`.
+     * The approval is cleared when the token is burned.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _burn(uint256 tokenId) internal virtual {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        ERC721Storage.TokenData storage tokenData = layout.tokens[tokenId];
+        ERC721Storage.OwnerData storage ownerData = layout.owners[tokenData.owner];
+
+        // uint256 prevOwnershipPacked = _packedOwnershipOf(tokenId);
+
+        address from = tokenData.owner;
+
+        _beforeTokenTransfers(from, address(0), tokenId, 1);
+
+        delete layout.tokenApprovals[tokenId];
+
+        ownerData.balance -= 1;
+        ownerData.numBurned += 1;
+
+        tokenData.burned = true;
+        tokenData.nextInitialized = true;
+
+        // Underflow of the sender's balance is impossible because we check for
+        // ownership above and the recipient's balance can't realistically overflow.
+        // Counter overflow is incredibly unrealistic as `tokenId` would have to be 2**256.
+        unchecked {
+            // Updates:
+            // - `balance -= 1`.
+            // - `numberBurned += 1`.
+            //
+            // We can directly decrement the balance, and increment the number burned.
+            // This is equivalent to `packed -= 1; packed += 1 << _BITPOS_NUMBER_BURNED;`.
+            _packedAddressData[from] += (1 << _BITPOS_NUMBER_BURNED) - 1;
+
+            // Updates:
+            // - `address` to the last owner.
+            // - `startTimestamp` to the timestamp of burning.
+            // - `burned` to `true`.
+            // - `nextInitialized` to `true`.
+            _packedOwnerships[tokenId] = _packOwnershipData(
+                from,
+                (_BITMASK_BURNED | _BITMASK_NEXT_INITIALIZED) | _nextExtraData(from, address(0), prevOwnershipPacked)
+            );
+
+            // If the next slot may not have been initialized (i.e. `nextInitialized == false`) .
+            if (prevOwnershipPacked & _BITMASK_NEXT_INITIALIZED == 0) {
+                uint256 nextTokenId = tokenId + 1;
+                // If the next slot's address is zero and not burned (i.e. packed value is zero).
+                if (_packedOwnerships[nextTokenId] == 0) {
+                    // If the next slot is within bounds.
+                    if (nextTokenId != _currentIndex) {
+                        // Initialize the next slot to maintain correctness for `ownerOf(tokenId + 1)`.
+                        _packedOwnerships[nextTokenId] = prevOwnershipPacked;
+                    }
+                }
+            }
+        }
+
+        emit Transfer(from, address(0), tokenId);
+        _afterTokenTransfers(from, address(0), tokenId, 1);
+
+        // Overflow not possible, as _burnCounter cannot be exceed _currentIndex times.
+        unchecked {
+            _burnCounter++;
+        }
+    }
+
+    /*====================
+        AUTHORITZATION
+    ====================*/
+
+    /**
+     * @dev Hook that is called before a set of serially-ordered token IDs
+     * are about to be transferred. This includes minting.
+     * And also called before burning one token.
+     *
+     * `startTokenId` - the first token ID to be transferred.
+     * `quantity` - the amount to be transferred.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, `from`'s `tokenId` will be
+     * transferred to `to`.
+     * - When `from` is zero, `tokenId` will be minted for `to`.
+     * - When `to` is zero, `tokenId` will be burned by `from`.
+     * - `from` and `to` are never both zero.
+     */
+    function _beforeTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity) internal virtual {}
+
+    /**
+     * @dev Hook that is called after a set of serially-ordered token IDs
+     * have been transferred. This includes minting.
+     * And also called after one token has been burned.
+     *
+     * `startTokenId` - the first token ID to be transferred.
+     * `quantity` - the amount to be transferred.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, `from`'s `tokenId` has been
+     * transferred to `to`.
+     * - When `from` is zero, `tokenId` has been minted for `to`.
+     * - When `to` is zero, `tokenId` has been burned by `from`.
+     * - `from` and `to` are never both zero.
+     */
+    function _afterTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity) internal virtual {}
+}

--- a/src/cores/ERC721/ERC721Internal.sol
+++ b/src/cores/ERC721/ERC721Internal.sol
@@ -1,30 +1,127 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {IERC721Internal} from "./IERC721.sol";
+import {IERC721Internal, IERC721Receiver} from "./IERC721.sol";
 import {ERC721Storage} from "./ERC721Storage.sol";
 
-abstract contract Internal is IERC721Internal {
+abstract contract ERC721Internal is IERC721Internal {
     /*===========
         VIEWS
     ===========*/
-    function foo() external virtual {}
 
-    /*=============
-        SETTERS
-    =============*/
+    function name() external virtual returns (string memory);
+    
+    function symbol() external virtual returns (string memory);
 
+    function _startTokenId() internal view virtual returns (uint256) {
+        return 0;
+    }
+
+    function totalSupply() public view virtual returns (uint256) {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        // Counter underflow is impossible as _burnCounter cannot be incremented
+        // more than `_currentIndex - _startTokenId()` times.
+        unchecked {
+            return layout.currentIndex - layout.burnCounter - _startTokenId();
+        }
+    }
+
+    function balanceOf(address owner) public view virtual returns (uint256) {
+        if (owner == address(0)) revert BalanceQueryForZeroAddress();
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        return layout.owners[owner].balance;
+    }
+
+    function tokenURI(uint256 tokenId) public view virtual returns (string memory);
+
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+        return _dataOf(tokenId).owner;
+    }
+    
     /**
-     * @dev Mints `quantity` tokens and transfers them to `to`.
-     *
-     * Requirements:
-     *
-     * - `to` cannot be the zero address.
-     * - `quantity` must be greater than 0.
-     *
-     * Emits a {Transfer} event for each mint.
+     * Returns the packed ownership data of `tokenId`.
      */
-    function _mint(address to, uint256 quantity) internal virtual {
+    function _dataOf(uint256 tokenId) private view returns (ERC721Storage.TokenData memory) {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        uint256 curr = tokenId;
+
+        unchecked {
+            if (curr >= _startTokenId()) {
+                if (curr < layout.currentIndex) {
+                    ERC721Storage.TokenData memory data = layout.tokens[curr];
+                    // If not burned.
+                    if (!data.burned) {
+                        // Invariant:
+                        // There will always be an initialized ownership slot
+                        // (i.e. `data.owner != address(0) && data.burned == false`)
+                        // before an unintialized ownership slot
+                        // (i.e. `data.owner == address(0) && data.burned == false`)
+                        // Hence, `curr` will not underflow.
+                        //
+                        // We can directly compare the packed value.
+                        // If the address is zero, packed will be zero.
+                        while (data.owner == address(0) && !data.burned) {
+                            data = layout.tokens[--curr];
+                        }
+                        return data;
+                    }
+                }
+            }
+        }
+        revert OwnerQueryForNonexistentToken();
+    }
+
+    // APPROVALS
+
+    function _exists(uint256 tokenId) internal view virtual returns (bool) {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        return _startTokenId() <= tokenId && tokenId < layout.currentIndex // If within bounds,
+            && !layout.tokens[tokenId].burned; // and not burned.
+    }
+
+    function _approve(address to, uint256 tokenId) internal {
+        if (to == address(0)) {
+            revert ApprovalInvalidOperator();
+        }
+        address owner = ownerOf(tokenId);
+
+        if (msg.sender != owner) {
+            if (!isApprovedForAll(owner, msg.sender)) {
+                revert ApprovalCallerNotOwnerNorApproved();
+            }
+        }
+        
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        layout.tokenApprovals[tokenId] = to;
+        emit Approval(owner, to, tokenId);
+    }
+
+    function _setApprovalForAll(address operator, bool approved) internal {
+        if (operator == address(0)) {
+            revert ApprovalInvalidOperator();
+        }
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        layout.operatorApprovals[msg.sender][operator] = approved;
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function getApproved(uint256 tokenId) public view virtual returns (address) {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        if (!_exists(tokenId)) revert ApprovalQueryForNonexistentToken();
+
+        return layout.tokenApprovals[tokenId];
+    }
+
+    function isApprovedForAll(address owner, address operator) public view virtual returns (bool) {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        return layout.operatorApprovals[owner][operator];
+    }
+
+    /*===============
+        OWNERSHIP
+    ===============*/
+
+    function _mint(address to, uint256 quantity) internal {
         if (quantity == 0) revert MintZeroQuantity();
         if (to == address(0)) revert MintToZeroAddress();
 
@@ -32,135 +129,166 @@ abstract contract Internal is IERC721Internal {
         
         uint256 startTokenId = layout.currentIndex;
 
-        _beforeTokenTransfers(address(0), to, startTokenId, quantity);
+        bytes memory beforeCheckData = _beforeTokenTransfers(address(0), to, startTokenId, quantity);
 
         ERC721Storage.OwnerData storage ownerData = layout.owners[to];
         ownerData.balance += uint64(quantity);
         ownerData.numMinted += uint64(quantity);
 
-        ERC721Storage.TokenData memory tokenData = ERC721Storage.TokenData(to, false, quantity == 1, false);
+        ERC721Storage.TokenData memory tokenData = ERC721Storage.TokenData(to, false, quantity == 1);
         layout.tokens[startTokenId] = tokenData;
 
         uint256 endIndex = startTokenId + quantity;
         for (uint256 tokenId = startTokenId; tokenId < endIndex; tokenId++) {
             emit Transfer(address(0), to, tokenId);
         }
-        layout.currentIndex = endIndex;
+        layout.currentIndex = uint64(endIndex);
         
-        _afterTokenTransfers(address(0), to, startTokenId, quantity);
+        _afterTokenTransfers(beforeCheckData);
     }
 
-    /**
-     * @dev Destroys `tokenId`.
-     * The approval is cleared when the token is burned.
-     *
-     * Requirements:
-     *
-     * - `tokenId` must exist.
-     *
-     * Emits a {Transfer} event.
-     */
-    function _burn(uint256 tokenId) internal virtual {
+    function _burn(uint256 tokenId) internal {
         ERC721Storage.Layout storage layout = ERC721Storage.layout();
-        ERC721Storage.TokenData storage tokenData = layout.tokens[tokenId];
-        ERC721Storage.OwnerData storage ownerData = layout.owners[tokenData.owner];
+        ERC721Storage.TokenData memory previousTokenData = _dataOf(tokenId); // reverts if tokenId is burned
+        address from = previousTokenData.owner;
+        ERC721Storage.OwnerData storage ownerData = layout.owners[from];
 
-        // uint256 prevOwnershipPacked = _packedOwnershipOf(tokenId);
+        // approvals?
 
-        address from = tokenData.owner;
+        bytes memory beforeCheckData = _beforeTokenTransfers(from, address(0), tokenId, 1);
 
-        _beforeTokenTransfers(from, address(0), tokenId, 1);
-
+        // clear approval from previous owner
         delete layout.tokenApprovals[tokenId];
 
         ownerData.balance -= 1;
         ownerData.numBurned += 1;
 
-        tokenData.burned = true;
-        tokenData.nextInitialized = true;
-
-        // Underflow of the sender's balance is impossible because we check for
-        // ownership above and the recipient's balance can't realistically overflow.
-        // Counter overflow is incredibly unrealistic as `tokenId` would have to be 2**256.
-        unchecked {
-            // Updates:
-            // - `balance -= 1`.
-            // - `numberBurned += 1`.
-            //
-            // We can directly decrement the balance, and increment the number burned.
-            // This is equivalent to `packed -= 1; packed += 1 << _BITPOS_NUMBER_BURNED;`.
-            _packedAddressData[from] += (1 << _BITPOS_NUMBER_BURNED) - 1;
-
-            // Updates:
-            // - `address` to the last owner.
-            // - `startTimestamp` to the timestamp of burning.
-            // - `burned` to `true`.
-            // - `nextInitialized` to `true`.
-            _packedOwnerships[tokenId] = _packOwnershipData(
-                from,
-                (_BITMASK_BURNED | _BITMASK_NEXT_INITIALIZED) | _nextExtraData(from, address(0), prevOwnershipPacked)
-            );
-
-            // If the next slot may not have been initialized (i.e. `nextInitialized == false`) .
-            if (prevOwnershipPacked & _BITMASK_NEXT_INITIALIZED == 0) {
-                uint256 nextTokenId = tokenId + 1;
-                // If the next slot's address is zero and not burned (i.e. packed value is zero).
-                if (_packedOwnerships[nextTokenId] == 0) {
-                    // If the next slot is within bounds.
-                    if (nextTokenId != _currentIndex) {
-                        // Initialize the next slot to maintain correctness for `ownerOf(tokenId + 1)`.
-                        _packedOwnerships[nextTokenId] = prevOwnershipPacked;
-                    }
+        // if next token is potentially uninitialized
+        if (!previousTokenData.nextInitialized) {
+            uint256 nextTokenId = tokenId + 1;
+            // if nextTokenId has been minted
+            if (nextTokenId < layout.currentIndex) {
+                ERC721Storage.TokenData storage nextTokenData = layout.tokens[nextTokenId];
+                // if next token is unowned
+                if (nextTokenData.owner == address(0) && !nextTokenData.burned) {
+                    // then implicit owner is previous token owner
+                    nextTokenData.owner = previousTokenData.owner;
+                    // default burned: false
+                    // default nextInitialized: false
                 }
             }
         }
 
-        emit Transfer(from, address(0), tokenId);
-        _afterTokenTransfers(from, address(0), tokenId, 1);
+        ERC721Storage.TokenData storage tokenData = layout.tokens[tokenId];
+        tokenData.burned = true;
+        tokenData.nextInitialized = true;
+        tokenData.owner = address(0); // not part of official 721A
 
-        // Overflow not possible, as _burnCounter cannot be exceed _currentIndex times.
-        unchecked {
-            _burnCounter++;
+        layout.burnCounter++;
+
+        emit Transfer(from, address(0), tokenId);
+        _afterTokenTransfers(beforeCheckData);
+    }
+
+    function _transfer(address from, address to, uint256 tokenId) internal {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        ERC721Storage.TokenData memory previousTokenData = _dataOf(tokenId); // reverts if tokenId is burned
+        ERC721Storage.OwnerData storage fromOwnerData = layout.owners[from];
+        ERC721Storage.OwnerData storage toOwnerData = layout.owners[to];
+
+        if (previousTokenData.owner != from) revert TransferFromIncorrectOwner();
+        if (to == address(0)) revert TransferToZeroAddress();
+
+        // approvals?
+
+        bytes memory beforeCheckData = _beforeTokenTransfers(from, to, tokenId, 1);
+
+        // clear approval from previous owner
+        delete layout.tokenApprovals[tokenId];
+
+        --fromOwnerData.balance;
+        ++toOwnerData.balance;
+
+        ERC721Storage.TokenData storage tokenData = layout.tokens[tokenId];
+        tokenData.owner = to;
+        tokenData.nextInitialized = true;
+
+        // if next token is potentially uninitialized
+        if (!previousTokenData.nextInitialized) {
+            uint256 nextTokenId = tokenId + 1;
+            // if nextTokenId has been minted
+            if (nextTokenId < layout.currentIndex) {
+                ERC721Storage.TokenData storage nextTokenData = layout.tokens[nextTokenId];
+                // if next token is unowned
+                if (nextTokenData.owner == address(0) && !nextTokenData.burned) {
+                    // then implicit owner is previous token owner
+                    nextTokenData.owner = previousTokenData.owner;
+                    // default burned: false
+                    // default nextInitialized: false
+                }
+            }
         }
+
+        emit Transfer(from, to, tokenId);
+        _afterTokenTransfers(beforeCheckData);
+    }
+
+    function _safeMint(address to, uint256 quantity) internal virtual {
+        ERC721Storage.Layout storage layout = ERC721Storage.layout();
+        _mint(to, quantity);
+
+        unchecked {
+            if (to.code.length != 0) {
+                uint256 end = layout.currentIndex;
+                uint256 index = end - quantity;
+                do {
+                    _checkOnERC721Received(address(0), to, index++, "");
+                } while (index < end);
+                // Reentrancy protection.
+                if (layout.currentIndex != end) revert();
+            }
+        }
+    }
+
+    function _safeTransfer(address from, address to, uint256 tokenId, bytes memory data) internal virtual {
+        _transfer(from, to, tokenId);
+        _checkOnERC721Received(from, to, tokenId, data);
     }
 
     /*====================
         AUTHORITZATION
     ====================*/
 
-    /**
-     * @dev Hook that is called before a set of serially-ordered token IDs
-     * are about to be transferred. This includes minting.
-     * And also called before burning one token.
-     *
-     * `startTokenId` - the first token ID to be transferred.
-     * `quantity` - the amount to be transferred.
-     *
-     * Calling conditions:
-     *
-     * - When `from` and `to` are both non-zero, `from`'s `tokenId` will be
-     * transferred to `to`.
-     * - When `from` is zero, `tokenId` will be minted for `to`.
-     * - When `to` is zero, `tokenId` will be burned by `from`.
-     * - `from` and `to` are never both zero.
-     */
-    function _beforeTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity) internal virtual {}
+    function _checkCanTransfer(address account, uint256 tokenId) internal virtual {
+        if (ownerOf(tokenId) != msg.sender) {
+            if (!isApprovedForAll(account, msg.sender)) {
+                if (getApproved(tokenId) != msg.sender) {
+                    revert TransferCallerNotOwnerNorApproved();
+                }
+            }
+        }
+    }
 
-    /**
-     * @dev Hook that is called after a set of serially-ordered token IDs
-     * have been transferred. This includes minting.
-     * And also called after one token has been burned.
-     *
-     * `startTokenId` - the first token ID to be transferred.
-     * `quantity` - the amount to be transferred.
-     *
-     * Calling conditions:
-     *
-     * - When `from` and `to` are both non-zero, `from`'s `tokenId` has been
-     * transferred to `to`.
-     * - When `from` is zero, `tokenId` has been minted for `to`.
-     * - When `to` is zero, `tokenId` has been burned by `from`.
-     * - `from` and `to` are never both zero.
-     */
-    function _afterTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity) internal virtual {}
+    function _checkOnERC721Received(address from, address to, uint256 tokenId, bytes memory data) internal {
+        if (to.code.length > 0) {
+            try IERC721Receiver(to).onERC721Received(msg.sender, from, tokenId, data) returns (bytes4 retval) {
+                if (retval != IERC721Receiver.onERC721Received.selector) {
+                    revert TransferToNonERC721ReceiverImplementer();
+                }
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert TransferToNonERC721ReceiverImplementer();
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        }
+    }
+
+    function _beforeTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity) internal virtual returns (bytes memory) {}
+
+    function _afterTokenTransfers(bytes memory beforeCheckData) internal virtual {}
 }

--- a/src/cores/ERC721/ERC721Mage.sol
+++ b/src/cores/ERC721/ERC721Mage.sol
@@ -8,7 +8,9 @@ import {Ownable, OwnableInternal} from "../../access/ownable/Ownable.sol";
 import {Access} from "../../access/Access.sol";
 import {ERC721AUpgradeable} from "./ERC721AUpgradeable.sol";
 import {ERC721} from "./ERC721.sol";
+import {ERC721Internal} from "./ERC721Internal.sol";
 import {TokenMetadata} from "../TokenMetadata/TokenMetadata.sol";
+import {TokenMetadataInternal} from "../TokenMetadata/TokenMetadataInternal.sol";
 import {
     ITokenURIExtension, IContractURIExtension
 } from "../../extension/examples/metadataRouter/IMetadataExtensions.sol";
@@ -25,12 +27,12 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         return OwnableInternal.owner();
     }
     
-
     /// @dev cannot call initialize within a proxy constructor, only post-deployment in a factory
     function initialize(address owner_, string calldata name_, string calldata symbol_, bytes calldata initData)
         external
         initializer
     {
+        ERC721Internal._initialize();
         _setName(name_);
         _setSymbol(symbol_);
         if (initData.length > 0) {
@@ -63,6 +65,14 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
     function supportsInterface(bytes4 interfaceId) public view override(Mage, ERC721) returns (bool) {
         return Mage.supportsInterface(interfaceId) || ERC721.supportsInterface(interfaceId);
     }
+    
+    function name() public view override(ERC721Internal, TokenMetadataInternal) returns (string memory) {
+        return TokenMetadataInternal.name();
+    }
+    
+    function symbol() public view override(ERC721Internal, TokenMetadataInternal) returns (string memory) {
+        return TokenMetadataInternal.symbol();
+    }
 
     // must override ERC721A implementation
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
@@ -76,7 +86,7 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         return IContractURIExtension(address(this)).ext_contractURI();
     }
 
-    function _checkCanUpdateTokenMetadata() internal override {
+    function _checkCanUpdateTokenMetadata() internal view override {
         _checkPermission(Operations.METADATA, msg.sender);
     }
 
@@ -103,25 +113,9 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         internal
         view
         override
-    {
-        (bytes8 operation, bytes memory data) = _getGuardParams(from, to, startTokenId, quantity);
-        checkGuardBefore(operation, data);
-    }
-
-    function _afterTokenTransfers(address from, address to, uint256 startTokenId, uint256 quantity)
-        internal
-        view
-        override
-    {
-        (bytes8 operation, bytes memory data) = _getGuardParams(from, to, startTokenId, quantity);
-        checkGuardAfter(operation, data);
-    }
-
-    function _getGuardParams(address from, address to, uint256 startTokenId, uint256 quantity)
-        internal
-        view
-        returns (bytes8 operation, bytes memory data)
-    {
+        returns (bytes memory beforeCheckData)
+    {   
+        bytes8 operation;
         if (from == address(0)) {
             operation = Operations.MINT;
         } else if (to == address(0)) {
@@ -129,8 +123,18 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         } else {
             operation = Operations.TRANSFER;
         }
-        data = abi.encode(msg.sender, from, to, startTokenId, quantity);
+        bytes memory data = abi.encode(msg.sender, from, to, startTokenId, quantity);
 
-        return (operation, data);
+        checkGuardBefore(operation, data);
+
+        return ""; // return checkGuardBefore
+    }
+
+    function _afterTokenTransfers(bytes memory checkBeforeData)
+        internal
+        view
+        override
+    {
+        // checkAfter(checkBeforeData, "")
     }
 }

--- a/src/cores/ERC721/ERC721Mage.sol
+++ b/src/cores/ERC721/ERC721Mage.sol
@@ -26,7 +26,7 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
     function owner() public view override(Access, OwnableInternal) returns (address) {
         return OwnableInternal.owner();
     }
-    
+
     /// @dev cannot call initialize within a proxy constructor, only post-deployment in a factory
     function initialize(address owner_, string calldata name_, string calldata symbol_, bytes calldata initData)
         external
@@ -52,7 +52,7 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
             _transferOwnership(owner_);
         }
     }
-    
+
     // override starting tokenId exposed by ERC721A
     function _startTokenId() internal pure override returns (uint256) {
         return 1;
@@ -65,12 +65,12 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
     function supportsInterface(bytes4 interfaceId) public view override(Mage, ERC721) returns (bool) {
         return Mage.supportsInterface(interfaceId) || ERC721.supportsInterface(interfaceId);
     }
-    
-    function name() public view override(ERC721Internal, TokenMetadataInternal) returns (string memory) {
+
+    function name() public view override(ERC721, TokenMetadataInternal) returns (string memory) {
         return TokenMetadataInternal.name();
     }
-    
-    function symbol() public view override(ERC721Internal, TokenMetadataInternal) returns (string memory) {
+
+    function symbol() public view override(ERC721, TokenMetadataInternal) returns (string memory) {
         return TokenMetadataInternal.symbol();
     }
 
@@ -114,7 +114,7 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         view
         override
         returns (address guard, bytes memory beforeCheckData)
-    {   
+    {
         bytes8 operation;
         if (from == address(0)) {
             operation = Operations.MINT;
@@ -128,11 +128,7 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         return checkGuardBefore(operation, data);
     }
 
-    function _afterTokenTransfers(address guard, bytes memory checkBeforeData)
-        internal
-        view
-        override
-    {
+    function _afterTokenTransfers(address guard, bytes memory checkBeforeData) internal view override {
         checkGuardAfter(guard, checkBeforeData, ""); // no execution data
     }
 }

--- a/src/cores/ERC721/ERC721Mage.sol
+++ b/src/cores/ERC721/ERC721Mage.sol
@@ -125,16 +125,17 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         }
         bytes memory data = abi.encode(msg.sender, from, to, startTokenId, quantity);
 
-        checkGuardBefore(operation, data);
+        (address guard, bytes memory checkBeforeData) = checkGuardBefore(operation, data);
 
-        return ""; // return checkGuardBefore
+        return abi.encode(guard, checkBeforeData);
     }
 
-    function _afterTokenTransfers(bytes memory checkBeforeData)
+    function _afterTokenTransfers(bytes memory wrappedCheckBeforeData)
         internal
         view
         override
     {
-        // checkAfter(checkBeforeData, "")
+        (address guard, bytes memory checkBeforeData) = abi.decode(wrappedCheckBeforeData, (address, bytes));
+        checkGuardAfter(guard, checkBeforeData, "");
     }
 }

--- a/src/cores/ERC721/ERC721Mage.sol
+++ b/src/cores/ERC721/ERC721Mage.sol
@@ -113,7 +113,7 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         internal
         view
         override
-        returns (bytes memory beforeCheckData)
+        returns (address guard, bytes memory beforeCheckData)
     {   
         bytes8 operation;
         if (from == address(0)) {
@@ -125,17 +125,14 @@ contract ERC721Mage is Mage, Ownable, Initializer, TokenMetadata, ERC721, IERC72
         }
         bytes memory data = abi.encode(msg.sender, from, to, startTokenId, quantity);
 
-        (address guard, bytes memory checkBeforeData) = checkGuardBefore(operation, data);
-
-        return abi.encode(guard, checkBeforeData);
+        return checkGuardBefore(operation, data);
     }
 
-    function _afterTokenTransfers(bytes memory wrappedCheckBeforeData)
+    function _afterTokenTransfers(address guard, bytes memory checkBeforeData)
         internal
         view
         override
     {
-        (address guard, bytes memory checkBeforeData) = abi.decode(wrappedCheckBeforeData, (address, bytes));
-        checkGuardAfter(guard, checkBeforeData, "");
+        checkGuardAfter(guard, checkBeforeData, ""); // no execution data
     }
 }

--- a/src/cores/ERC721/ERC721Storage.sol
+++ b/src/cores/ERC721/ERC721Storage.sol
@@ -5,10 +5,8 @@ library ERC721Storage {
     bytes32 internal constant SLOT = keccak256(abi.encode(uint256(keccak256("mage.ERC721")) - 1));
 
     struct Layout {
-        string name;
-        string symbol;
-        uint256 currentIndex;
-        uint256 burnCounter;
+        uint64 currentIndex; // max supply is 18e18
+        uint64 burnCounter;
         mapping(uint256 => TokenData) tokens;
         mapping(address => OwnerData) owners;
         mapping(uint256 => address) tokenApprovals;
@@ -16,19 +14,17 @@ library ERC721Storage {
     }
 
     struct TokenData {
-        // ERC721
+        // ERC-721
         address owner;
-        // ERC721A
+        // ERC-721A
         bool burned;
         bool nextInitialized;
-        // ERC_
-        bool locked;
     }
 
     struct OwnerData {
-        // ERC721
+        // ERC-721
         uint64 balance;
-        // ERC721A
+        // ERC-721A
         uint64 numMinted;
         uint64 numBurned;
     }

--- a/src/cores/ERC721/ERC721Storage.sol
+++ b/src/cores/ERC721/ERC721Storage.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+library ERC721Storage {
+    bytes32 internal constant SLOT = keccak256(abi.encode(uint256(keccak256("mage.ERC721")) - 1));
+
+    struct Layout {
+        string name;
+        string symbol;
+        uint256 currentIndex;
+        uint256 burnCounter;
+        mapping(uint256 => TokenData) tokens;
+        mapping(address => OwnerData) owners;
+        mapping(uint256 => address) tokenApprovals;
+        mapping(address => mapping(address => bool)) operatorApprovals;
+    }
+
+    struct TokenData {
+        // ERC721
+        address owner;
+        // ERC721A
+        bool burned;
+        bool nextInitialized;
+        // ERC_
+        bool locked;
+    }
+
+    struct OwnerData {
+        // ERC721
+        uint64 balance;
+        // ERC721A
+        uint64 numMinted;
+        uint64 numBurned;
+    }
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/cores/ERC721/ERC721Storage.sol
+++ b/src/cores/ERC721/ERC721Storage.sol
@@ -5,28 +5,29 @@ library ERC721Storage {
     bytes32 internal constant SLOT = keccak256(abi.encode(uint256(keccak256("mage.ERC721")) - 1));
 
     struct Layout {
-        uint64 currentIndex; // max supply is 18e18
-        uint64 burnCounter;
-        mapping(uint256 => TokenData) tokens;
-        mapping(address => OwnerData) owners;
+        uint256 currentIndex; // max supply is 18e18
+        uint256 burnCounter;
         mapping(uint256 => address) tokenApprovals;
         mapping(address => mapping(address => bool)) operatorApprovals;
+        mapping(uint256 => TokenData) tokens;
+        mapping(address => OwnerData) owners;
     }
 
     struct TokenData {
         // ERC-721
-        address owner;
+        address owner; //         [0..159]
         // ERC-721A
-        bool burned;
-        bool nextInitialized;
+        uint48 ownerUpdatedAt; // [160..207]
+        bool burned; //           [208..215]
+        bool nextInitialized; //  [216..223]
     }
 
     struct OwnerData {
         // ERC-721
-        uint64 balance;
+        uint64 balance; //   [0..63]
         // ERC-721A
-        uint64 numMinted;
-        uint64 numBurned;
+        uint64 numMinted; // [64..127]
+        uint64 numBurned; // [128..191]
     }
 
     function layout() internal pure returns (Layout storage l) {

--- a/src/cores/ERC721/IERC721.sol
+++ b/src/cores/ERC721/IERC721.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.13;
 interface IERC721Internal {
     // events
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
-    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
     event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 
     // errors
     error ApprovalCallerNotOwnerNorApproved();
@@ -23,11 +23,21 @@ interface IERC721Internal {
     error MintERC2309QuantityExceedsLimit();
     error OwnershipNotInitializedForExtraData();
 
-
     // views
+    function totalSupply() external view returns (uint256);
+    function getApproved(uint256 tokenId) external view returns (address operator);
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+    function balanceOf(address owner) external view returns (uint256);
+    function ownerOf(uint256 tokenId) external view returns (address);
 }
 
 interface IERC721External {
+    // views
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+
     // setters
     function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
     function safeTransferFrom(address from, address to, uint256 tokenId) external;
@@ -38,12 +48,8 @@ interface IERC721External {
 
 interface IERC721 is IERC721Internal, IERC721External {}
 
-
 interface IERC721Receiver {
-    function onERC721Received(
-        address operator,
-        address from,
-        uint256 tokenId,
-        bytes calldata data
-    ) external returns (bytes4);
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)
+        external
+        returns (bytes4);
 }

--- a/src/cores/ERC721/IERC721.sol
+++ b/src/cores/ERC721/IERC721.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IERC721Internal {
+    // events
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    // errors
+    error MintZeroQuantity();
+    error MintToZeroAddress();
+
+    // views
+    function foo() external;
+}
+
+interface IERC721External {
+    // setters
+    function bar() external;
+}
+
+interface IERC721 is IERC721Internal, IERC721External {}

--- a/src/cores/ERC721/IERC721.sol
+++ b/src/cores/ERC721/IERC721.sol
@@ -4,18 +4,46 @@ pragma solidity ^0.8.13;
 interface IERC721Internal {
     // events
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
 
     // errors
-    error MintZeroQuantity();
+    error ApprovalCallerNotOwnerNorApproved();
+    error ApprovalQueryForNonexistentToken();
+    error ApprovalInvalidOperator();
+    error BalanceQueryForZeroAddress();
     error MintToZeroAddress();
+    error MintZeroQuantity();
+    error OwnerQueryForNonexistentToken();
+    error TransferCallerNotOwnerNorApproved();
+    error TransferFromIncorrectOwner();
+    error TransferToNonERC721ReceiverImplementer();
+    error TransferToZeroAddress();
+    error URIQueryForNonexistentToken();
+    error MintERC2309QuantityExceedsLimit();
+    error OwnershipNotInitializedForExtraData();
+
 
     // views
-    function foo() external;
 }
 
 interface IERC721External {
     // setters
-    function bar() external;
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+    function transferFrom(address from, address to, uint256 tokenId) external;
+    function approve(address to, uint256 tokenId) external;
+    function setApprovalForAll(address operator, bool approved) external;
 }
 
 interface IERC721 is IERC721Internal, IERC721External {}
+
+
+interface IERC721Receiver {
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external returns (bytes4);
+}

--- a/src/cores/TokenMetadata/ITokenMetadata.sol
+++ b/src/cores/TokenMetadata/ITokenMetadata.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface ITokenMetadataInternal {
+    // events
+    event NameUpdated(string name);
+    event SymbolUpdated(string symbol);
+
+    // errors
+
+    // views
+    function name() external view returns (string calldata);
+    function symbol() external view returns (string calldata);
+}
+
+interface ITokenMetadataExternal {
+    // setters
+    function setName(string calldata name) external;
+    function setSymbol(string calldata symbol) external;
+}
+
+interface ITokenMetadata is ITokenMetadataInternal, ITokenMetadataExternal {}

--- a/src/cores/TokenMetadata/TokenMetadata.sol
+++ b/src/cores/TokenMetadata/TokenMetadata.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {ITokenMetadataExternal} from "./ITokenMetadata.sol";
+import {TokenMetadataInternal} from "./TokenMetadataInternal.sol";
+import {TokenMetadataStorage} from "./TokenMetadataStorage.sol";
+
+abstract contract TokenMetadata is TokenMetadataInternal, ITokenMetadataExternal {
+    /*===========
+        VIEWS
+    ===========*/
+
+    /*=============
+        SETTERS
+    =============*/
+    
+    function setName(string calldata name_) external canUpdateTokenMetadata {
+        _setName(name_);
+    }
+    
+    function setSymbol(string calldata symbol_) external canUpdateTokenMetadata {
+        _setSymbol(symbol_);
+    }
+
+    /*====================
+        AUTHORITZATION
+    ====================*/
+
+    modifier canUpdateTokenMetadata() {
+        _checkCanUpdateTokenMetadata();
+        _;
+    }
+
+    function _checkCanUpdateTokenMetadata() internal view virtual;
+}

--- a/src/cores/TokenMetadata/TokenMetadataInternal.sol
+++ b/src/cores/TokenMetadata/TokenMetadataInternal.sol
@@ -8,12 +8,13 @@ abstract contract TokenMetadataInternal is ITokenMetadataInternal {
     /*===========
         VIEWS
     ===========*/
-    function name() external view returns (string memory) {
+    
+    function name() public view virtual returns (string memory) {
         TokenMetadataStorage.Layout storage layout = TokenMetadataStorage.layout();
         return layout.name;
     }
     
-    function symbol() external view returns (string memory) {
+    function symbol() public view virtual returns (string memory) {
         TokenMetadataStorage.Layout storage layout = TokenMetadataStorage.layout();
         return layout.symbol;
     }

--- a/src/cores/TokenMetadata/TokenMetadataInternal.sol
+++ b/src/cores/TokenMetadata/TokenMetadataInternal.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {ITokenMetadataInternal} from "./ITokenMetadata.sol";
+import {TokenMetadataStorage} from "./TokenMetadataStorage.sol";
+
+abstract contract TokenMetadataInternal is ITokenMetadataInternal {
+    /*===========
+        VIEWS
+    ===========*/
+    function name() external view returns (string memory) {
+        TokenMetadataStorage.Layout storage layout = TokenMetadataStorage.layout();
+        return layout.name;
+    }
+    
+    function symbol() external view returns (string memory) {
+        TokenMetadataStorage.Layout storage layout = TokenMetadataStorage.layout();
+        return layout.symbol;
+    }
+
+    /*=============
+        SETTERS
+    =============*/
+    
+    function _setName(string calldata name_) internal {
+        TokenMetadataStorage.layout().name = name_;
+    }
+    
+    function _setSymbol(string calldata symbol_) internal {
+        TokenMetadataStorage.layout().symbol = symbol_;
+    }
+
+    /*====================
+        AUTHORITZATION
+    ====================*/
+}

--- a/src/cores/TokenMetadata/TokenMetadataStorage.sol
+++ b/src/cores/TokenMetadata/TokenMetadataStorage.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+library TokenMetadataStorage {
+    bytes32 internal constant SLOT = keccak256(abi.encode(uint256(keccak256("mage.TokenMetadata")) - 1));
+
+    struct Layout {
+        string name;
+        string symbol;
+    }
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/guard/GuardsInternal.sol
+++ b/src/guard/GuardsInternal.sol
@@ -12,44 +12,21 @@ abstract contract GuardsInternal is IGuardsInternal {
         HOOKS
     ===========*/
 
-    modifier checkGuardBeforeAndAfter(bytes8 operation, bytes calldata data) {
-        _checkGuard(operation, data, GuardsStorage.CheckType.BEFORE);
-        _;
-        _checkGuard(operation, data, GuardsStorage.CheckType.AFTER);
-    }
-
-    function checkGuardBefore(bytes8 operation, bytes memory data) public view returns (address guard) {
-        return _checkGuard(operation, data, GuardsStorage.CheckType.BEFORE);
-    }
-
-    function checkGuardAfter(bytes8 operation, bytes memory data) public view returns (address guard) {
-        return _checkGuard(operation, data, GuardsStorage.CheckType.AFTER);
-    }
-
-    function _checkGuard(bytes8 operation, bytes memory data, GuardsStorage.CheckType check)
-        internal
-        view
-        returns (address guard)
-    {
+    function checkGuardBefore(bytes8 operation, bytes memory data) public view returns (address guard, bytes memory checkBeforeData) {
         guard = guardOf(operation);
         if (guard.autoReject()) {
             revert GuardRejected(operation, guard);
         } else if (guard.autoApprove()) {
-            return guard;
+            return (guard, "");
         }
 
-        bool guardApproves;
-        if (check == GuardsStorage.CheckType.BEFORE) {
-            guardApproves = IGuard(guard).checkBefore(msg.sender, data);
-        } else {
-            guardApproves = IGuard(guard).checkAfter(msg.sender, data);
-        }
+        checkBeforeData = IGuard(guard).checkBefore(msg.sender, data); // revert will cascade
 
-        if (!guardApproves) {
-            revert GuardRejected(operation, guard);
-        } else {
-            return guard;
-        }
+        return (guard, checkBeforeData);
+    }
+
+    function checkGuardAfter(address guard, bytes memory checkBeforeData, bytes memory executionData) public view {
+        IGuard(guard).checkAfter(checkBeforeData, executionData); // revert will cascade
     }
 
     /*===========

--- a/src/guard/examples/TimeRangeGuard.sol
+++ b/src/guard/examples/TimeRangeGuard.sol
@@ -29,14 +29,13 @@ contract TimeRangeGuard is IGuard {
         return (range.start, range.end);
     }
 
-    function checkBefore(address, bytes calldata) external view returns (bool) {
+    function checkBefore(address, bytes calldata) external view returns (bytes memory) {
         _checkTimeRange();
-        return true;
+        return bytes("");
     }
 
-    function checkAfter(address, bytes calldata) external view returns (bool) {
+    function checkAfter(bytes calldata, bytes calldata) external view {
         _checkTimeRange();
-        return true;
     }
 
     function _checkTimeRange() internal view {

--- a/src/guard/interface/IGuard.sol
+++ b/src/guard/interface/IGuard.sol
@@ -3,6 +3,6 @@ pragma solidity ^0.8.13;
 
 interface IGuard {
     function contractURI() external view returns (string memory);
-    function checkBefore(address operator, bytes calldata data) external view returns (bool);
-    function checkAfter(address operator, bytes calldata data) external view returns (bool);
+    function checkBefore(address operator, bytes calldata data) external view returns (bytes memory checkBeforeData);
+    function checkAfter(bytes calldata checkBeforeData, bytes calldata executionData) external view;
 }

--- a/src/guard/interface/IGuards.sol
+++ b/src/guard/interface/IGuards.sol
@@ -17,8 +17,8 @@ interface IGuardsInternal {
     error GuardRejected(bytes8 operation, address guard);
 
     // hooks
-    function checkGuardBefore(bytes8 operation, bytes calldata data) external view returns (address guard);
-    function checkGuardAfter(bytes8 operation, bytes calldata data) external view returns (address guard);
+    function checkGuardBefore(bytes8 operation, bytes calldata data) external view returns (address guard, bytes memory checkBeforeData);
+    function checkGuardAfter(address guard, bytes calldata checkBeforeData, bytes calldata executionData) external view;
     // views
     function guardOf(bytes8 operation) external view returns (address implementation);
     function getAllGuards() external view returns (Guard[] memory Guards);

--- a/test/cores/ERC721/ERC721.t.sol
+++ b/test/cores/ERC721/ERC721.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC721} from "src/cores/ERC721/ERC721.sol";
+import {IERC721, IERC721Internal} from "src/cores/ERC721/IERC721.sol";
+import {ERC721Storage} from "src/cores/ERC721/ERC721Storage.sol";
+
+contract ERC721Test is Test {
+    // to store expected revert errors
+    bytes err;
+
+    ERC721Harness erc721;
+
+    function setUp() public {
+        erc721 = new ERC721Harness();
+    }
+
+    function test_setUp() public {
+        // sanity checks
+    }
+
+    function test_mint(address to, uint8 quantity) public {
+        vm.assume(quantity > 0);
+        erc721.mint(to, quantity);
+
+        assertEq(erc721.totalSupply(), quantity);
+        assertEq(erc721.balanceOf(to), quantity);
+        for (uint tokenId; tokenId < quantity; tokenId++) {
+            assertEq(erc721.ownerOf(tokenId), to);
+        }
+    }
+
+    function test_mintRevertZeroQuantity(address to) public {
+        vm.expectRevert(IERC721Internal.MintZeroQuantity.selector);
+        erc721.mint(to, 0);
+    }
+
+    function test_burn(address to, uint8 mintQuantity, uint8 burnQuantity) public {
+        vm.assume(mintQuantity > 0);
+        vm.assume(burnQuantity < mintQuantity);
+
+        erc721.mint(to, mintQuantity);
+
+        uint256 preBurnBalance = erc721.balanceOf(to);
+        for (uint i; i < burnQuantity; i++) {
+            uint256 tokenId = i;
+            erc721.burn(tokenId);
+            assertEq(erc721.totalSupply(), preBurnBalance - (i + 1));
+            assertEq(erc721.balanceOf(to), preBurnBalance - (i + 1));
+            vm.expectRevert(IERC721Internal.OwnerQueryForNonexistentToken.selector);
+            erc721.ownerOf(tokenId);
+        }
+    }
+
+    function test_transfer(address from, address to, uint8 mintQuantity, uint8 transferQuantity) public {
+        vm.assume(mintQuantity > 0);
+        vm.assume(transferQuantity < mintQuantity);
+
+        erc721.mint(from, mintQuantity);
+
+        uint256 preTransferBalanceFrom = erc721.balanceOf(from);
+        uint256 preTransferBalanceTo = erc721.balanceOf(to);
+        for (uint i; i < transferQuantity; i++) {
+            uint256 tokenId = i;
+            erc721.transfer(from, to, tokenId);
+            assertEq(erc721.balanceOf(from), preTransferBalanceFrom - (i + 1));
+            assertEq(erc721.balanceOf(to), preTransferBalanceTo + (i + 1));
+            assertEq(erc721.ownerOf(tokenId), to);
+        }
+        assertEq(erc721.totalSupply(), preTransferBalanceFrom);
+    }
+}
+
+contract ERC721Harness is ERC721 {
+
+    function name() public pure override returns (string memory) {
+        return "ERC721";
+    }
+
+    function symbol() public pure override returns (string memory) {
+        return "ERC721";
+    }
+    
+    function tokenURI(uint256) public pure override returns (string memory) {
+        return "uri";
+    }
+
+    function exists(uint256 tokenId) public view returns (bool) {
+        return _exists(tokenId);
+    }
+
+    function mint(address to, uint256 quantity) public {
+        _mint(to, quantity);
+    }
+    
+    function burn(uint256 tokenId) public {
+        _burn(tokenId);
+    }
+
+    function transfer(address from, address to, uint256 tokenId) public {
+        _transfer(from, to, tokenId);
+    }
+
+    function safeMint(address to, uint256 quantity) public {
+        _safeMint(to, quantity);
+    }
+
+    function safeTransfer(address from, address to, uint256 tokenId, bytes memory data) public {
+        _safeTransfer(from, to, tokenId, data);
+    }
+
+    function checkCanTransfer(address account, uint256 tokenId) public {
+        _checkCanTransfer(account, tokenId);
+    }
+
+    function checkOnERC721Received(address from, address to, uint256 tokenId, bytes memory data) public {
+        _checkOnERC721Received(from, to, tokenId, data);
+    }
+}

--- a/test/guard/Guards.t.sol
+++ b/test/guard/Guards.t.sol
@@ -139,37 +139,38 @@ contract GuardsTest is Test, Guards, IGuards {
         }
     }
 
-    // function test_checkGuard(bytes8 operation, bytes8 operation2, bytes8 operation3) public {
-    //     // prevent overlapping operations
-    //     vm.assume(operation != operation2 && operation2 != operation3 && operation != operation3);
-    //     setGuard(operation, address(timeRangeGuard));
+    function test_checkGuard(bytes8 operation, bytes8 operation2, bytes8 operation3) public {
+        // prevent overlapping operations
+        vm.assume(operation != operation2 && operation2 != operation3 && operation != operation3);
+        setGuard(operation, address(timeRangeGuard));
 
-    //     // assert timeRangeGuard not setUp- reverts at `getValidTimeRange()` call
-    //     vm.expectRevert("RANGE_UNDEFINED");
-    //     this.checkGuardBefore(operation, "");
-    //     vm.expectRevert("RANGE_UNDEFINED");
-    //     this.checkGuardBefore(operation, "");
+        // assert timeRangeGuard not setUp- reverts at `getValidTimeRange()` call
+        vm.expectRevert("RANGE_UNDEFINED");
+        this.checkGuardBefore(operation, "");
 
-    //     // set up
-    //     timeRangeGuard.setUp(uint40(block.timestamp), type(uint40).max);
+        // set up
+        timeRangeGuard.setUp(uint40(block.timestamp), type(uint40).max);
 
-    //     timeRangeGuard.getValidTimeRange(address(this));
+        timeRangeGuard.getValidTimeRange(address(this));
 
-    //     // move forward any amt of blocks to pass `_checkTimeRange()` check on start
-    //     skip(42);
-    //     assertEq(this.checkGuardBefore(operation, ""), address(timeRangeGuard));
-    //     assertEq(this.checkGuardAfter(operation, ""), address(timeRangeGuard));
+        // move forward any amt of blocks to pass `_checkTimeRange()` check on start
+        skip(42);
+        (address guard, bytes memory checkBeforeData) = this.checkGuardBefore(operation, "");
+        assertEq(guard, address(timeRangeGuard));
+        this.checkGuardAfter(guard, checkBeforeData, ""); // should not revert
 
-    //     // autoReject operation3
-    //     setGuard(operation3, autoRejectAddr);
+        // autoReject operation3
+        setGuard(operation3, autoRejectAddr);
 
-    //     // operation2 is autoapproved by default
-    //     assertEq(_checkGuard(operation2, "", GuardsStorage.CheckType.BEFORE), address(0x0));
-    //     // since operation3 is set to autoReject address, expect GuardRejected error
-    //     err = abi.encodeWithSelector(GuardRejected.selector, operation3, autoRejectAddr);
-    //     vm.expectRevert(err);
-    //     _checkGuard(operation3, "", GuardsStorage.CheckType.BEFORE);
-    // }
+        // operation2 is autoapproved by default
+        (guard, checkBeforeData) = this.checkGuardBefore(operation2, "");
+        assertEq(guard, address(0x0));
+        assertEq(checkBeforeData, "");
+        // since operation3 is set to autoReject address, expect GuardRejected error
+        err = abi.encodeWithSelector(GuardRejected.selector, operation3, autoRejectAddr);
+        vm.expectRevert(err);
+        this.checkGuardBefore(operation3, "");
+    }
 
     /*==============
         OVERRIDES

--- a/test/guard/Guards.t.sol
+++ b/test/guard/Guards.t.sol
@@ -139,37 +139,37 @@ contract GuardsTest is Test, Guards, IGuards {
         }
     }
 
-    function test_checkGuard(bytes8 operation, bytes8 operation2, bytes8 operation3) public {
-        // prevent overlapping operations
-        vm.assume(operation != operation2 && operation2 != operation3 && operation != operation3);
-        setGuard(operation, address(timeRangeGuard));
+    // function test_checkGuard(bytes8 operation, bytes8 operation2, bytes8 operation3) public {
+    //     // prevent overlapping operations
+    //     vm.assume(operation != operation2 && operation2 != operation3 && operation != operation3);
+    //     setGuard(operation, address(timeRangeGuard));
 
-        // assert timeRangeGuard not setUp- reverts at `getValidTimeRange()` call
-        vm.expectRevert("RANGE_UNDEFINED");
-        this.checkGuardBefore(operation, "");
-        vm.expectRevert("RANGE_UNDEFINED");
-        this.checkGuardBefore(operation, "");
+    //     // assert timeRangeGuard not setUp- reverts at `getValidTimeRange()` call
+    //     vm.expectRevert("RANGE_UNDEFINED");
+    //     this.checkGuardBefore(operation, "");
+    //     vm.expectRevert("RANGE_UNDEFINED");
+    //     this.checkGuardBefore(operation, "");
 
-        // set up
-        timeRangeGuard.setUp(uint40(block.timestamp), type(uint40).max);
+    //     // set up
+    //     timeRangeGuard.setUp(uint40(block.timestamp), type(uint40).max);
 
-        timeRangeGuard.getValidTimeRange(address(this));
+    //     timeRangeGuard.getValidTimeRange(address(this));
 
-        // move forward any amt of blocks to pass `_checkTimeRange()` check on start
-        skip(42);
-        assertEq(this.checkGuardBefore(operation, ""), address(timeRangeGuard));
-        assertEq(this.checkGuardAfter(operation, ""), address(timeRangeGuard));
+    //     // move forward any amt of blocks to pass `_checkTimeRange()` check on start
+    //     skip(42);
+    //     assertEq(this.checkGuardBefore(operation, ""), address(timeRangeGuard));
+    //     assertEq(this.checkGuardAfter(operation, ""), address(timeRangeGuard));
 
-        // autoReject operation3
-        setGuard(operation3, autoRejectAddr);
+    //     // autoReject operation3
+    //     setGuard(operation3, autoRejectAddr);
 
-        // operation2 is autoapproved by default
-        assertEq(_checkGuard(operation2, "", GuardsStorage.CheckType.BEFORE), address(0x0));
-        // since operation3 is set to autoReject address, expect GuardRejected error
-        err = abi.encodeWithSelector(GuardRejected.selector, operation3, autoRejectAddr);
-        vm.expectRevert(err);
-        _checkGuard(operation3, "", GuardsStorage.CheckType.BEFORE);
-    }
+    //     // operation2 is autoapproved by default
+    //     assertEq(_checkGuard(operation2, "", GuardsStorage.CheckType.BEFORE), address(0x0));
+    //     // since operation3 is set to autoReject address, expect GuardRejected error
+    //     err = abi.encodeWithSelector(GuardRejected.selector, operation3, autoRejectAddr);
+    //     vm.expectRevert(err);
+    //     _checkGuard(operation3, "", GuardsStorage.CheckType.BEFORE);
+    // }
 
     /*==============
         OVERRIDES
@@ -191,6 +191,6 @@ contract MaliciousGuard is IGuard {
     }
 
     function contractURI() external view returns (string memory) {}
-    function checkBefore(address operator, bytes calldata data) external view returns (bool) {}
-    function checkAfter(address operator, bytes calldata data) external view returns (bool) {}
+    function checkBefore(address operator, bytes calldata data) external view returns (bytes memory checkBeforeData) {}
+    function checkAfter(bytes calldata checkBeforeData, bytes calldata data) external view {}
 }


### PR DESCRIPTION
- Rewrite ERC721A with namespaced storage
- Updates guards to follow cleaner pattern of passing `beforeCheckData` from the before hook into the after hook
- Refactored the `_checkBeforeTokenTransfer` and `_checkAfterTokenTransfer` interfaces to support our guards pattern
- Updated Guards tests
- Added minimal ERC721 tests