### PR TITLE
Add ERC1155 implementation

### DIFF
--- a/src/cores/ERC1155/ERC1155.sol
+++ b/src/cores/ERC1155/ERC1155.sol
@@ -181,17 +181,16 @@ abstract contract ERC1155 is IERC1155 {
                 if (fromBalance < value) {
                     revert ERC1155InsufficientBalance(from, fromBalance, value, id);
                 }
-                unchecked {
-                    // Overflow not possible: value <= fromBalance
-                    layout.balances[id][from] = fromBalance - value;
-                }
+                layout.balances[id][from] = fromBalance - value;
             } else {
+                // increase total supply if minting
                 layout.totalSupply[id] += value;
             }
 
             if (to != address(0)) {
                 layout.balances[id][to] += value;
             } else {
+                // decrease total supply if burning
                 layout.totalSupply[id] -= value;
             }
         }

--- a/src/cores/ERC1155/ERC1155.sol
+++ b/src/cores/ERC1155/ERC1155.sol
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IERC1155} from "openzeppelin-contracts/token/ERC1155/IERC1155.sol";
+import {IERC1155MetadataURI} from "openzeppelin-contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol";
+import {IERC1155Errors} from "openzeppelin-contracts/interfaces/draft-IERC6093.sol";
+import {ERC1155Storage} from "./ERC1155Storage.sol";
+
+abstract contract ERC1155 is IERC1155, IERC1155MetadataURI {
+
+    /*==============
+        METADATA
+    ==============*/
+
+    /// @dev require override
+    function name() public view virtual returns (string memory);
+
+    /// @dev require override
+    function symbol() public view virtual returns (string memory);
+
+    /// @dev require override
+    function uri(uint256 tokenId) public view virtual returns (string memory);
+
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        // The interface IDs are constants representing the first 4 bytes
+        // of the XOR of all function selectors in the interface.
+        // See: [ERC165](https://eips.ethereum.org/EIPS/eip-165)
+        // (e.g. `bytes4(i.functionA.selector ^ i.functionB.selector ^ ...)`)
+        return interfaceId == 0x01ffc9a7 // ERC165 interface ID for ERC165.
+            || interfaceId == type(IERC1155).interfaceId // ERC165 interface ID for ERC721.
+            || interfaceId == type(IERC1155MetadataURI).interfaceId; // ERC165 interface ID for ERC721Metadata.
+    }
+
+    /*===========
+        VIEWS
+    ===========*/
+
+    function balanceOf(address account, uint256 id) public view virtual returns (uint256) {
+        return ERC1155Storage.layout().balances[id][account];
+    }
+
+    function balanceOfBatch(
+        address[] memory accounts,
+        uint256[] memory ids
+    ) public view virtual returns (uint256[] memory) {
+        if (accounts.length != ids.length) {
+            revert ERC1155InvalidArrayLength(ids.length, accounts.length);
+        }
+
+        uint256[] memory batchBalances = new uint256[](accounts.length);
+
+        for (uint256 i = 0; i < accounts.length; ++i) {
+            batchBalances[i] = balanceOf(accounts.unsafeMemoryAccess(i), ids.unsafeMemoryAccess(i));
+        }
+
+        return batchBalances;
+    }
+
+    function isApprovedForAll(address account, address operator) public view virtual returns (bool) {
+        return ERC1155Storage.layout().operatorApprovals[account][operator];
+    }
+
+    /*======================
+        EXTERNAL SETTERS
+    ======================*/
+
+    function setApprovalForAll(address operator, bool approved) public virtual {
+        _setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes memory data) public virtual {
+        _checkCanTransfer(from);
+        _safeTransferFrom(from, to, id, value, data);
+    }
+
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
+    ) public virtual {
+        _checkCanTransfer(from);
+        _safeBatchTransferFrom(from, to, ids, values, data);
+    }
+
+    /*======================
+        INTERNAL SETTERS
+    ======================*/
+
+    function _setApprovalForAll(address owner, address operator, bool approved) internal virtual {
+        if (operator == address(0)) {
+            revert ERC1155InvalidOperator(address(0));
+        }
+        _operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+    function _safeTransferFrom(address from, address to, uint256 id, uint256 value, bytes memory data) internal {
+        (uint256[] memory ids, uint256[] memory values) = _asSingletonArrays(id, value);
+        _safeBatchTransferFrom(from, to, ids, values, data);
+    }
+
+    function _safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
+    ) internal {
+        if (to == address(0)) {
+            revert ERC1155InvalidReceiver(address(0));
+        }
+        if (from == address(0)) {
+            revert ERC1155InvalidSender(address(0));
+        }
+        _updateWithAcceptanceCheck(from, to, ids, values, data);
+    }
+
+    function _mint(address to, uint256 id, uint256 value, bytes memory data) internal {
+        (uint256[] memory ids, uint256[] memory values) = _asSingletonArrays(id, value);
+        _mintBatch(to, ids, values, data);
+    }
+
+    function _mintBatch(address to, uint256[] memory ids, uint256[] memory values, bytes memory data) internal {
+        if (to == address(0)) {
+            revert ERC1155InvalidReceiver(address(0));
+        }
+        _updateWithAcceptanceCheck(address(0), to, ids, values, data);
+    }
+
+    function _burn(address from, uint256 id, uint256 value) internal {
+        (uint256[] memory ids, uint256[] memory values) = _asSingletonArrays(id, value);
+        _burnBatch(from, ids, values, "");
+    }
+
+    function _burnBatch(address from, uint256[] memory ids, uint256[] memory values) internal {
+        if (from == address(0)) {
+            revert ERC1155InvalidSender(address(0));
+        }
+        _updateWithAcceptanceCheck(from, address(0), ids, values, "");
+    }
+
+    function _updateWithAcceptanceCheck(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
+    ) internal virtual {
+        _update(from, to, ids, values);
+        if (to != address(0)) {
+            address operator = msg.sender;
+            if (ids.length == 1) {
+                uint256 id = ids.unsafeMemoryAccess(0);
+                uint256 value = values.unsafeMemoryAccess(0);
+                _doSafeTransferAcceptanceCheck(operator, from, to, id, value, data);
+            } else {
+                _doSafeBatchTransferAcceptanceCheck(operator, from, to, ids, values, data);
+            }
+        }
+    }
+
+    /// @dev overriden from OZ by adding totalSupply math
+    function _update(address from, address to, uint256[] memory ids, uint256[] memory values) internal virtual {
+        if (ids.length != values.length) {
+            revert ERC1155InvalidArrayLength(ids.length, values.length);
+        }
+        ERC1155Storage.Layout storage layout = ERC1155Storage.layout();
+
+        // check before
+        (address guard, bytes memory beforeCheckData) = _beforeTokenTransfer(from, to, ids, values);
+
+        address operator = msg.sender;
+
+        for (uint256 i = 0; i < ids.length; ++i) {
+            uint256 id = ids.unsafeMemoryAccess(i);
+            uint256 value = values.unsafeMemoryAccess(i);
+
+            if (from != address(0)) {
+                uint256 fromBalance = layout.balances[id][from];
+                if (fromBalance < value) {
+                    revert ERC1155InsufficientBalance(from, fromBalance, value, id);
+                }
+                unchecked {
+                    // Overflow not possible: value <= fromBalance
+                    layout.balances[id][from] = fromBalance - value;
+                }
+            } else {
+                layout.totalSupply[id] += value;
+            }
+
+            if (to != address(0)) {
+                layout.balances[id][to] += value;
+            } else {
+                layout.totalSupply[id] -= value;
+            }
+        }
+
+        if (ids.length == 1) {
+            uint256 id = ids.unsafeMemoryAccess(0);
+            uint256 value = values.unsafeMemoryAccess(0);
+            emit TransferSingle(operator, from, to, id, value);
+        } else {
+            emit TransferBatch(operator, from, to, ids, values);
+        }
+
+        // check after
+        _afterTokenTransfers(guard, beforeCheckData);
+    }
+
+    function _asSingletonArrays(
+        uint256 element1,
+        uint256 element2
+    ) private pure returns (uint256[] memory array1, uint256[] memory array2) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Load the free memory pointer
+            array1 := mload(0x40)
+            // Set array length to 1
+            mstore(array1, 1)
+            // Store the single element at the next word after the length (where content starts)
+            mstore(add(array1, 0x20), element1)
+
+            // Repeat for next array locating it right after the first array
+            array2 := add(array1, 0x40)
+            mstore(array2, 1)
+            mstore(add(array2, 0x20), element2)
+
+            // Update the free memory pointer by pointing after the second array
+            mstore(0x40, add(array2, 0x40))
+        }
+    }
+
+    /*====================
+        AUTHORIZATION
+    ====================*/
+
+    function _checkCanTransfer(address from) internal virtual {
+        if (from != msg.sender && !isApprovedForAll(from, msg.sender)) {
+            revert ERC1155MissingApprovalForAll(msg.sender, from);
+        }
+    }
+    
+    function _doSafeTransferAcceptanceCheck(
+        address operator,
+        address from,
+        address to,
+        uint256 id,
+        uint256 value,
+        bytes memory data
+    ) private {
+        if (to.code.length > 0) {
+            try IERC1155Receiver(to).onERC1155Received(operator, from, id, value, data) returns (bytes4 response) {
+                if (response != IERC1155Receiver.onERC1155Received.selector) {
+                    // Tokens rejected
+                    revert ERC1155InvalidReceiver(to);
+                }
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    // non-ERC1155Receiver implementer
+                    revert ERC1155InvalidReceiver(to);
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        }
+    }
+
+    function _doSafeBatchTransferAcceptanceCheck(
+        address operator,
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values,
+        bytes memory data
+    ) private {
+        if (to.code.length > 0) {
+            try IERC1155Receiver(to).onERC1155BatchReceived(operator, from, ids, values, data) returns (
+                bytes4 response
+            ) {
+                if (response != IERC1155Receiver.onERC1155BatchReceived.selector) {
+                    // Tokens rejected
+                    revert ERC1155InvalidReceiver(to);
+                }
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    // non-ERC1155Receiver implementer
+                    revert ERC1155InvalidReceiver(to);
+                } else {
+                    /// @solidity memory-safe-assembly
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        }
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values
+    ) internal virtual returns (address guard, bytes memory beforeCheckData);
+
+    function _afterTokenTransfer(address guard, bytes memory checkBeforeData) internal virtual;
+}

--- a/src/cores/ERC1155/ERC1155Mage.sol
+++ b/src/cores/ERC1155/ERC1155Mage.sol
@@ -88,7 +88,7 @@ contract ERC1155Mage is Mage, Ownable, Initializable, TokenMetadata, ERC1155, IE
         _mint(recipient, tokenId, value, "");
     }
 
-    function burn(address from, uint256 tokenId, uint256 value) external {
+    function burnFrom(address from, uint256 tokenId, uint256 value) external {
         if (!hasPermission(Operations.BURN, msg.sender)) {
             _checkCanTransfer(from);
         }

--- a/src/cores/ERC1155/ERC1155Mage.sol
+++ b/src/cores/ERC1155/ERC1155Mage.sol
@@ -7,7 +7,6 @@ import {Mage} from "../../Mage.sol";
 import {Ownable, OwnableInternal} from "../../access/ownable/Ownable.sol";
 import {Access} from "../../access/Access.sol";
 import {ERC1155} from "./ERC1155.sol";
-import {ERC1155Internal} from "./ERC1155Internal.sol";
 import {TokenMetadata} from "../TokenMetadata/TokenMetadata.sol";
 import {TokenMetadataInternal} from "../TokenMetadata/TokenMetadataInternal.sol";
 import {
@@ -33,7 +32,6 @@ contract ERC1155Mage is Mage, Ownable, Initializable, TokenMetadata, ERC1155, IE
         external
         initializer
     {
-        ERC1155Internal._initialize();
         _setName(name_);
         _setSymbol(symbol_);
         if (initData.length > 0) {
@@ -120,7 +118,7 @@ contract ERC1155Mage is Mage, Ownable, Initializable, TokenMetadata, ERC1155, IE
         } else {
             operation = Operations.TRANSFER;
         }
-        bytes memory data = abi.encode(msg.sender, from, to, startTokenId, quantity);
+        bytes memory data = abi.encode(msg.sender, from, to, ids, values);
 
         return checkGuardBefore(operation, data);
     }

--- a/src/cores/ERC1155/ERC1155Mage.sol
+++ b/src/cores/ERC1155/ERC1155Mage.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Address} from "openzeppelin-contracts/utils/Address.sol";
+
+import {Mage} from "../../Mage.sol";
+import {Ownable, OwnableInternal} from "../../access/ownable/Ownable.sol";
+import {Access} from "../../access/Access.sol";
+import {ERC1155} from "./ERC1155.sol";
+import {ERC1155Internal} from "./ERC1155Internal.sol";
+import {TokenMetadata} from "../TokenMetadata/TokenMetadata.sol";
+import {TokenMetadataInternal} from "../TokenMetadata/TokenMetadataInternal.sol";
+import {
+    ITokenURIExtension, IContractURIExtension
+} from "../../extension/examples/metadataRouter/IMetadataExtensions.sol";
+import {Operations} from "../../lib/Operations.sol";
+import {PermissionsStorage} from "../../access/permissions/PermissionsStorage.sol";
+import {IERC1155Mage} from "./interface/IERC1155Mage.sol";
+import {Initializable} from "../../lib/initializable/Initializable.sol";
+
+/// @notice apply Mage pattern to ERC1155 NFTs
+contract ERC1155Mage is Mage, Ownable, Initializable, TokenMetadata, ERC1155, IERC1155Mage {
+
+    constructor() Initializable() {}
+    
+    // owner stored explicitly
+    function owner() public view override(Access, OwnableInternal) returns (address) {
+        return OwnableInternal.owner();
+    }
+
+    /// @dev cannot call initialize within a proxy constructor, only post-deployment in a factory
+    function initialize(address owner_, string calldata name_, string calldata symbol_, bytes calldata initData)
+        external
+        initializer
+    {
+        ERC1155Internal._initialize();
+        _setName(name_);
+        _setSymbol(symbol_);
+        if (initData.length > 0) {
+            /// @dev if called within a constructor, self-delegatecall will not work because this address does not yet have
+            /// bytecode implementing the init functions -> revert here with nicer error message
+            if (address(this).code.length == 0) {
+                revert CannotInitializeWhileConstructing();
+            }
+            // make msg.sender the owner to ensure they have all permissions for further initialization
+            _transferOwnership(msg.sender);
+            Address.functionDelegateCall(address(this), initData);
+            // if sender and owner arg are different, transfer ownership to desired address
+            if (msg.sender != owner_) {
+                _transferOwnership(owner_);
+            }
+        } else {
+            _transferOwnership(owner_);
+        }
+    }
+
+    /*==============
+        METADATA
+    ==============*/
+
+    function name() public view override(ERC1155, TokenMetadataInternal) returns (string memory) {
+        return TokenMetadataInternal.name();
+    }
+
+    function symbol() public view override(ERC1155, TokenMetadataInternal) returns (string memory) {
+        return TokenMetadataInternal.symbol();
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(Mage, ERC1155) returns (bool) {
+        return Mage.supportsInterface(interfaceId) || ERC1155.supportsInterface(interfaceId);
+    }
+
+    // must override ERC1155 implementation
+    function uri(uint256 tokenId) public view override returns (string memory) {
+        // to avoid clashing selectors, use standardized `ext_` prefix
+        return ITokenURIExtension(address(this)).ext_tokenURI(tokenId);
+    }
+
+    // include contractURI as modern standard for NFTs
+    function contractURI() public view override returns (string memory) {
+        // to avoid clashing selectors, use standardized `ext_` prefix
+        return IContractURIExtension(address(this)).ext_contractURI();
+    }
+
+    /*=============
+        SETTERS
+    =============*/
+
+    function mintTo(address recipient, uint256 tokenId, uint256 value) external onlyPermission(Operations.MINT) {
+        _mint(recipient, tokenId, value, "");
+    }
+
+    function burn(address from, uint256 tokenId, uint256 value) external {
+        if (!hasPermission(Operations.BURN, msg.sender)) {
+            _checkCanTransfer(from);
+        }
+        _burn(from, tokenId, value);
+    }
+
+    /*===========
+        GUARD
+    ===========*/
+
+    function _beforeTokenTransfers(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory values
+    )
+        internal
+        view
+        override
+        returns (address guard, bytes memory beforeCheckData)
+    {
+        bytes8 operation;
+        if (from == address(0)) {
+            operation = Operations.MINT;
+        } else if (to == address(0)) {
+            operation = Operations.BURN;
+        } else {
+            operation = Operations.TRANSFER;
+        }
+        bytes memory data = abi.encode(msg.sender, from, to, startTokenId, quantity);
+
+        return checkGuardBefore(operation, data);
+    }
+
+    function _afterTokenTransfers(address guard, bytes memory checkBeforeData) internal view override {
+        checkGuardAfter(guard, checkBeforeData, ""); // no execution data
+    }
+
+    /*===================
+        AUTHORIZATION
+    ===================*/
+
+    function _checkCanUpdatePermissions() internal view override {
+        _checkPermission(Operations.PERMISSIONS, msg.sender);
+    }
+
+    function _checkCanUpdateGuards() internal view override {
+        _checkPermission(Operations.GUARDS, msg.sender);
+    }
+
+    function _checkCanExecute() internal view override {
+        _checkPermission(Operations.EXECUTE, msg.sender);
+    }
+
+    function _checkCanUpdateInterfaces() internal view override {
+        _checkPermission(Operations.INTERFACE, msg.sender);
+    }
+
+    function _checkCanUpdateTokenMetadata() internal view override {
+        _checkPermission(Operations.METADATA, msg.sender);
+    }
+
+    // changes to core functionality must be restricted to owners to protect admins overthrowing
+    function _checkCanUpdateExtensions() internal view override {
+        _checkOwner();
+    }
+
+    function _authorizeUpgrade(address) internal view override {
+        _checkOwner();
+    }
+}

--- a/src/cores/ERC1155/ERC1155Storage.sol
+++ b/src/cores/ERC1155/ERC1155Storage.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 library ERC1155Storage {
-    bytes32 internal constant SLOT = keccak256(abi.encode(uint256(keccak256("0xrails.ERC1155")) - 1));
+    bytes32 internal constant SLOT = keccak256(abi.encode(uint256(keccak256("mage.ERC1155")) - 1));
 
     struct Layout {
         // id => account => balance

--- a/src/cores/ERC1155/ERC1155Storage.sol
+++ b/src/cores/ERC1155/ERC1155Storage.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+library ERC1155Storage {
+    bytes32 internal constant SLOT = keccak256(abi.encode(uint256(keccak256("0xrails.ERC1155")) - 1));
+
+    struct Layout {
+        // id => account => balance
+        mapping(uint256 => mapping(address => uint256)) balances;
+        // account => operator => t/f
+        mapping(address => mapping(address => bool)) operatorApprovals;
+        // id => supply
+        mapping(uint256 => uint256) totalSupply;
+    }
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/cores/ERC1155/interface/IERC1155.sol
+++ b/src/cores/ERC1155/interface/IERC1155.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IERC1155 {
+    // events
+    event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
+    event TransferBatch(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256[] ids,
+        uint256[] values
+    );
+    event ApprovalForAll(address indexed account, address indexed operator, bool approved);
+    event URI(string value, uint256 indexed id);
+
+    // errors, EIP6903 compliant
+    error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);
+    error ERC1155InvalidSender(address sender);
+    error ERC1155InvalidReceiver(address receiver);
+    error ERC1155MissingApprovalForAll(address operator, address owner);
+    error ERC1155InvalidApprover(address approver);
+    error ERC1155InvalidOperator(address operator);
+    error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);
+
+    // metadata
+    function uri(uint256 id) external view returns (string memory);
+
+    // views
+    function balanceOf(address account, uint256 id) external view returns (uint256);
+    function balanceOfBatch(
+        address[] calldata accounts,
+        uint256[] calldata ids
+    ) external view returns (uint256[] memory);
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+
+    // setters
+    function setApprovalForAll(address operator, bool approved) external;
+    function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes calldata data) external;
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external;
+}

--- a/src/cores/ERC1155/interface/IERC1155Mage.sol
+++ b/src/cores/ERC1155/interface/IERC1155Mage.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IERC1155Mage {
+    error CannotInitializeWhileConstructing();
+
+    function mintTo(address recipient, uint256 tokenId, uint256 value) external;
+    function burn(address from, uint256 tokenId, uint256 value) external;
+    function initialize(address owner, string calldata name, string calldata symbol, bytes calldata initData)
+        external;
+}

--- a/src/cores/ERC1155/interface/IERC1155Mage.sol
+++ b/src/cores/ERC1155/interface/IERC1155Mage.sol
@@ -2,10 +2,8 @@
 pragma solidity ^0.8.13;
 
 interface IERC1155Mage {
-    error CannotInitializeWhileConstructing();
-
     function mintTo(address recipient, uint256 tokenId, uint256 value) external;
-    function burn(address from, uint256 tokenId, uint256 value) external;
+    function burnFrom(address from, uint256 tokenId, uint256 value) external;
     function initialize(address owner, string calldata name, string calldata symbol, bytes calldata initData)
         external;
 }

--- a/src/cores/ERC20/ERC20Mage.sol
+++ b/src/cores/ERC20/ERC20Mage.sol
@@ -81,8 +81,10 @@ contract ERC20Mage is Mage, Ownable, Initializable, TokenMetadata, ERC20, IERC20
     }
 
     /// @dev rework allowance to also allow permissioned users burn unconditionally
-    function burn(address from, uint256 amount) external returns(bool) {
-        _spendAllowance(from, msg.sender, amount);
+    function burnFrom(address from, uint256 amount) external returns(bool) {
+        if (!hasPermission(Operations.BURN, msg.sender)) {
+            _spendAllowance(from, msg.sender, amount);
+        }
         _burn(from, amount);
         return true;
     }
@@ -105,7 +107,7 @@ contract ERC20Mage is Mage, Ownable, Initializable, TokenMetadata, ERC20, IERC20
         } else {
             operation = Operations.TRANSFER;
         }
-        bytes memory data = abi.encode(from, to, amount);
+        bytes memory data = abi.encode(msg.sender, from, to, amount);
 
         return checkGuardBefore(operation, data);
     }

--- a/src/cores/ERC20/interface/IERC20Mage.sol
+++ b/src/cores/ERC20/interface/IERC20Mage.sol
@@ -3,10 +3,8 @@ pragma solidity ^0.8.13;
 
 /// @notice using the consistent Access layer, expose external functions for interacting with core token logic
 interface IERC20Mage {
-    error CannotInitializeWhileConstructing();
-
     function mintTo(address recipient, uint256 amount) external returns (bool);
-    function burn(address owner, uint256 amount) external returns (bool);
+    function burnFrom(address from, uint256 amount) external returns (bool);
     function initialize(address owner, string calldata name, string calldata symbol, bytes calldata initData)
         external;
 }

--- a/src/cores/ERC721/ERC721Mage.sol
+++ b/src/cores/ERC721/ERC721Mage.sol
@@ -99,8 +99,8 @@ contract ERC721Mage is Mage, Ownable, Initializable, TokenMetadata, ERC721, IERC
     }
 
     function burn(uint256 tokenId) external {
-        if (msg.sender != ownerOf(tokenId)) {
-            _checkPermission(Operations.BURN, msg.sender);
+        if (!hasPermission(Operations.BURN, msg.sender)) {
+            _checkCanTransfer(ownerOf(tokenId), tokenId); /// @todo resolve gas inefficiency of reading ownerOf twice
         }
         _burn(tokenId);
     }

--- a/src/cores/ERC721/ERC721Mage.sol
+++ b/src/cores/ERC721/ERC721Mage.sol
@@ -123,6 +123,7 @@ contract ERC721Mage is Mage, Ownable, Initializable, TokenMetadata, ERC721, IERC
         } else {
             operation = Operations.TRANSFER;
         }
+        /// @todo add msg.sender operator into guard data to support cases of "only allow X operation with Y module"
         bytes memory data = abi.encode(from, to, startTokenId, quantity);
 
         return checkGuardBefore(operation, data);

--- a/src/cores/ERC721/interface/IERC721Mage.sol
+++ b/src/cores/ERC721/interface/IERC721Mage.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.13;
 
 /// @notice using the consistent Access layer, expose external functions for interacting with core token logic
 interface IERC721Mage {
-    error CannotInitializeWhileConstructing();
-
     function mintTo(address recipient, uint256 quantity) external;
     function burn(uint256 tokenId) external;
     function initialize(address owner, string calldata name, string calldata symbol, bytes calldata initData)

--- a/src/lib/initializable/IInitializable.sol
+++ b/src/lib/initializable/IInitializable.sol
@@ -8,6 +8,7 @@ interface IInitializableInternal {
     // errors
     error AlreadyInitialized();
     error NotInitializing();
+    error CannotInitializeWhileConstructing();
 
     // views
     function initialized() external view returns (bool);

--- a/test/cores/ERC721/ERC721.t.sol
+++ b/test/cores/ERC721/ERC721.t.sol
@@ -410,6 +410,7 @@ contract ERC721Test is Test {
         vm.assume(from != address(0x0) && to != address(0x0)); 
         vm.assume(from != badOperator && from != to);
         vm.assume(mintQuantity > 0);
+        vm.assume(badOperator != address(0));
 
         erc721.mint(from, mintQuantity);
 

--- a/test/cores/ERC721/ERC721Mage.t.sol
+++ b/test/cores/ERC721/ERC721Mage.t.sol
@@ -15,8 +15,9 @@ import {Extensions} from "src/extension/Extensions.sol";
 import {IExtensions} from "src/extension/interface/IExtensions.sol";
 import {TimeRangeGuard} from "src/guard/examples/TimeRangeGuard.sol";
 import {ERC721ReceiverImplementer} from "test/cores/ERC721/helpers/ERC721ReceiverImplementer.sol";
+import {MockAccountDeployer} from "test/lib/MockAccount.sol";
 
-contract ERC721MageTest is Test {
+contract ERC721MageTest is Test, MockAccountDeployer {
 
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
 
@@ -263,10 +264,10 @@ contract ERC721MageTest is Test {
     }
 
     function test_approve(
-        address from, 
         address operator, 
         uint8 mintQuantity
     ) public {
+        address from = createAccount();
         // prevent mint/approve/delegatecalls to address(0x0)
         vm.assume(from != address(0x0) && from != address(erc721MageProxy));
         vm.assume(operator != address(0x0)); 
@@ -388,15 +389,15 @@ contract ERC721MageTest is Test {
     }
 
     function test_transferFrom(
-        address from, 
-        address to, 
         address operator,
         uint8 mintQuantity, 
         uint8 transferQuantity
     ) public {
+        address from = createAccount();
+        address to = createAccount();
         // prevent transfers, approvals, delegatecalls to/from address(0x0)
-        vm.assume(from != address(0x0) && to != address(0x0) && operator != address(0x0)); 
-        vm.assume(from != operator && from != to);
+        vm.assume(operator != address(0x0)); 
+        vm.assume(from != operator && operator != to);
         vm.assume(from != address(erc721MageProxy));
         vm.assume(mintQuantity > 0);
         vm.assume(transferQuantity < mintQuantity / 3);
@@ -479,6 +480,7 @@ contract ERC721MageTest is Test {
         vm.assume(from != address(0x0) && to != address(0x0)); 
         vm.assume(from != badOperator && from != to);
         vm.assume(mintQuantity > 0);
+        vm.assume(badOperator != address(0));
 
         vm.prank(owner);
         erc721MageProxy.mintTo(from, mintQuantity);

--- a/test/lib/MockAccount.sol
+++ b/test/lib/MockAccount.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+// set up receivers to accept token transfers
+contract MockAccount {
+    receive() external payable virtual {}
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes memory
+    ) public pure returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes memory
+    ) public pure returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(
+        address,
+        address,
+        uint256[] memory,
+        uint256[] memory,
+        bytes memory
+    ) public pure returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+}
+
+contract MockAccountDeployer {
+    function createAccount() public returns (address account) {
+        return address(new MockAccount());
+    }
+}


### PR DESCRIPTION
- add ERC1155 implementation with ERC7201 namespaced storage convention
- add `totalSupply` storage and view per tokenId
- add hooks for before and after token transfers
- add ERC1155Mage implementation
- update ERC20Mage implementation for guards and burning
- fix tests with `MockAccount` and `MockAccountDeployer` for token receiver hooks